### PR TITLE
Add runtime config note to setup

### DIFF
--- a/docs/content/en/setup.md
+++ b/docs/content/en/setup.md
@@ -35,6 +35,16 @@ export default {
 };
 ```
 
+If you have a `runtimeConfig` in your `nuxt.config.js` file then you will need to add the `directus` config object to it:
+
+```js{}[nuxt.config.js]
+runtimeConfig: {
+  directus: {
+    url: "",
+  },
+}
+```
+
 <alert type="success">
 
 That's it! You can now use [Directus](/usage/useDirectusToken) in your Nuxt app ✨


### PR DESCRIPTION
If you have your own runtime configuration in nuxt.config file then you need to manually add the directus object otherwise you get an error. Adding this into the docs.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Added documentation when runtimeConfig object is used in nuxt.config.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
N/A Documentation change only.
