### PR TITLE
fix: stringify "deep" key on get item by id

### DIFF
--- a/src/runtime/composables/useDirectusItems.ts
+++ b/src/runtime/composables/useDirectusItems.ts
@@ -38,6 +38,12 @@ export const useDirectusItems = () => {
   };
 
   const getItemById = async <T>(data: DirectusItemRequest): Promise<T> => {
+    if (data.params?.filter) {
+      (data.params.filter as unknown) = JSON.stringify(data.params.filter);
+    }
+    if (data.params?.deep) {
+      (data.params.deep as unknown) = JSON.stringify(data.params.deep);
+    }
     const items = await directus<{ data: T[] }>(
       `/items/${data.collection}/${data.id}`,
       {


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Description
When we query a single item, we can add a deep parameter to embed many-to-many relations. So, this param should be stringifyied. Applying the same operation to filter is more coherent, regarding the other functions.

If a developer use this feature and already do a JSON.stringify upper, it could add escaping backslashs to the string.

