### PR TITLE
fix(docs): correct usage of getThumbnail

### DIFF
--- a/docs/content/en/usage/useDirectusFiles.md
+++ b/docs/content/en/usage/useDirectusFiles.md
@@ -59,6 +59,6 @@ Directus will generate the image with the given [`parameters`](https://github.co
 
 <script setup lang="ts">
 const fileId = "5e47b7e6-fd78-400c-821f-0dca4a176f4f";
-const { getThumbnail: img } = useDirectus();
+const { getThumbnail: img } = useDirectusFiles();
 </script>
 ```


### PR DESCRIPTION
Fixed a small mistake in the docs:
"getThumbnail" is defined in "useDirectusFiles" not "useDirectus"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
