### PR TITLE
fix: :bug: playground fetch collection now works

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -99,14 +99,14 @@ const fetchArticles = async () => {
 
     router.push('/d')
   } catch (e) { }
+}
 
-  const fetchCollections = async () => {
-    try {
-      const collections = await getCollections()
-      console.log(collections)
+const fetchCollections = async () => {
+  try {
+    const collections = await getCollections()
+    console.log(collections)
 
-      router.push('/d')
-    } catch (e) { }
-  }
+    router.push('/d')
+  } catch (e) { }
 }
 </script>


### PR DESCRIPTION
Moved fetchCollection function outside of fetch articles

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Fixed the retrieval of collections call in the playground.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

A fix to existing functionality, no documentation or tests required.
