### PR TITLE
feat: add token to getThumbnail url query params

### DIFF
--- a/src/runtime/composables/useDirectusFiles.ts
+++ b/src/runtime/composables/useDirectusFiles.ts
@@ -3,12 +3,16 @@ import {
   DirectusItemRequest,
   DirectusFileRequest,
 } from "../types";
+import { useRuntimeConfig } from "#app";
 import { useDirectusUrl } from "./useDirectusUrl";
 import { useDirectus } from "./useDirectus";
+import { useDirectusToken } from "./useDirectusToken";
 
 export const useDirectusFiles = () => {
+  const config = useRuntimeConfig();
   const directusUrl = useDirectusUrl();
   const directus = useDirectus();
+  const token = useDirectusToken();
 
   const getFiles = async <T>(data: DirectusFileRequest): Promise<T[]> => {
     if (data.params?.filter) {
@@ -41,6 +45,11 @@ export const useDirectusFiles = () => {
         url.searchParams.append("withoutEnlargement", "true");
       if (options.fit) url.searchParams.append("fit", options.fit);
       if (options.format) url.searchParams.append("format", options.format);
+    }
+    if (token && token.value) {
+      url.searchParams.append("access_token", token.value);
+    } else if (config.directus.token) {
+      url.searchParams.append("access_token", config.directus.token);
     }
     return url.href;
   };


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This adds the `access_token` query param to the url generated by the `getThumbnail` function, using the directus JWT if the user is logged in or the static token if set in the config.

This allows the URL generated to be used in an `<img>` tag directly, even if files are not publicly accessible and require the token for authentication.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
