### PR TITLE
feat: add Avif type support to DirectusThumbnailFormat

### DIFF
--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -97,7 +97,7 @@ export interface DirectusUserDeletion {
   users: Array<string> | string;
 }
 
-export type DirectusThumbnailFormat = 'jpg' | 'png' | 'webp' | 'tiff';
+export type DirectusThumbnailFormat = 'jpg' | 'png' | 'webp' | 'tiff' | 'avif';
 
 export type DirectusThumbnailFit = 'cover' | 'contain' | 'inside' | 'outside';
 


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Directus [v9.25.0](https://github.com/directus/directus/releases/tag/v9.25.0) added support for `AVIF` image format (https://github.com/directus/directus/pull/17303). `'avif'` is now a supported type in `getThumbnail()`

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
