### PR TITLE
Fixed ability to install from Github + Fixed typo

### DIFF
--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -38,13 +38,25 @@ Auto refesh tokens
 
 The function that get called if the `autoRefresh` fail
 
-## `maxAgeRefreshToken`
+## `cookieMaxAge`
 
 - Default: `604800`
 
 Need to be the same as specified in your directus config; this is the max amount of milliseconds that your refresh cookie will be kept in the browser. 
 
 Auto refesh tokens
+
+## `cookieSameSite`
+
+- Default: `lax`
+
+The SameSite attribute for auth cookies.
+
+## `cookieSecure`
+
+- Default: false
+
+The Secure attribute for auth cookies.
 
 ## `fetchUserParams`
 

--- a/docs/content/4.Types/8.DirectusInvite.md
+++ b/docs/content/4.Types/8.DirectusInvite.md
@@ -9,7 +9,7 @@ export interface DirectusInviteCreation {
   invite_url?: string
 };
 
-export interface DirectusInviteAccept {
+export interface DirectusAcceptInvite {
   token: string;
   password: string
 };

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -5,5 +5,6 @@ export default defineNuxtConfig({
   directus: {
     url: 'http://localhost:8055/',
     devtools: true,
+    maxAgeRefreshToken: 10000,
   }
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'path'
 import { fileURLToPath } from 'url'
 import { defu } from 'defu'
-import { defineNuxtModule, addPlugin, addImportsDir, isNuxt2 } from '@nuxt/kit'
+import { defineNuxtModule, addPlugin, addImportsDir } from '@nuxt/kit'
 import { joinURL } from 'ufo'
 import { DirectusQueryParams } from './runtime/types'
 
@@ -68,6 +68,14 @@ export interface ModuleOptions {
   cookieMaxAge?: number;
 
   /**
+   * The max age for auth cookies in seconds.
+   * This should match your directus env key REFRESH_TOKEN_TTL
+   * @type string
+   * @default 604800
+   */
+  maxAgeRefreshToken?: number;
+
+  /**
    * The SameSite attribute for auth cookies.
    * @type string
    * @default 'lax'
@@ -104,28 +112,35 @@ export default defineNuxtModule<ModuleOptions>({
     cookieSameSite: 'lax',
     cookieSecure: false
   },
-  setup (options, nuxt) {
-    nuxt.options.runtimeConfig.public = nuxt.options.runtimeConfig.public || {}
-    nuxt.options.runtimeConfig.public.directus = defu(nuxt.options.runtimeConfig.public.directus, {
-      url: options.url,
-      autoFetch: options.autoFetch,
-      autoRefresh: options.autoRefresh,
-      onAutoRefreshFailure: options.onAutoRefreshFailure,
-      fetchUserParams: options.fetchUserParams,
-      token: options.token,
-      devtools: options.devtools,
-      cookieNameToken: options.cookieNameToken,
-      cookieNameRefreshToken: options.cookieNameRefreshToken,
-      cookieMaxAge: options.cookieMaxAge,
-      cookieSameSite: options.cookieSameSite,
-      cookieSecure: options.cookieSecure
-    })
-
+  setup(options, nuxt) {
+    nuxt.options.runtimeConfig.public = nuxt.options.runtimeConfig.public || {};
+    nuxt.options.runtimeConfig.public.directus = defu(
+      nuxt.options.runtimeConfig.public.directus,
+      {
+        url: options.url,
+        autoFetch: options.autoFetch,
+        autoRefresh: options.autoRefresh,
+        onAutoRefreshFailure: options.onAutoRefreshFailure,
+        fetchUserParams: options.fetchUserParams,
+        token: options.token,
+        devtools: options.devtools,
+        cookieNameToken: options.cookieNameToken,
+        cookieNameRefreshToken: options.cookieNameRefreshToken,
+        cookieMaxAge: options.cookieMaxAge || options.maxAgeRefreshToken,
+        cookieSameSite: options.cookieSameSite,
+        cookieSecure: options.cookieSecure
+      })
+      
     const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))
     nuxt.options.build.transpile.push(runtimeDir)
 
     addPlugin(resolve(runtimeDir, 'plugin'))
     addImportsDir(resolve(runtimeDir, 'composables'))
+    if (options.maxAgeRefreshToken) {
+      console.warn(
+        'maxAgeRefreshToken is deprecated, please use cookieMaxAge instead'
+        );
+      }
 
     if (options.devtools) {
       const adminUrl = joinURL(nuxt.options.runtimeConfig.public.directus.url, '/admin/')

--- a/src/module.ts
+++ b/src/module.ts
@@ -60,25 +60,26 @@ export interface ModuleOptions {
   cookieNameRefreshToken?: string;
 
   /**
-   * The max age for the refresh token cookie in seconds.
+   * The max age for auth cookies in seconds.
    * This should match your directus env key REFRESH_TOKEN_TTL
    * @type string
+   * @default 604800
    */
-  maxAgeRefreshToken?: number;
+  cookieMaxAge?: number;
 
   /**
-   * The SameSite attribute for the refresh token cookie.
+   * The SameSite attribute for auth cookies.
    * @type string
-   * @default 'strict'
+   * @default 'lax'
    */
-  sameSiteRefreshToken?: 'strict' | 'lax' | 'none' | undefined;
+  cookieSameSite?: 'strict' | 'lax' | 'none' | undefined;
 
   /**
-   * The Secure attribute for the refresh token cookie.
+   * The Secure attribute for auth cookies.
    * @type boolean
-   * @default true
+   * @default false
    */
-  isSecureRefreshToken?: boolean;
+  cookieSecure?: boolean;
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -99,9 +100,9 @@ export default defineNuxtModule<ModuleOptions>({
     cookieNameRefreshToken: 'directus_refresh_token',
 
     // Nuxt Cookies Docs @ https://nuxt.com/docs/api/composables/use-cookie
-    maxAgeRefreshToken: 604800,
-    sameSiteRefreshToken: 'lax',
-    isSecureRefreshToken: false
+    cookieMaxAge: 604800,
+    cookieSameSite: 'lax',
+    cookieSecure: false
   },
   setup (options, nuxt) {
     nuxt.options.runtimeConfig.public = nuxt.options.runtimeConfig.public || {}
@@ -115,9 +116,9 @@ export default defineNuxtModule<ModuleOptions>({
       devtools: options.devtools,
       cookieNameToken: options.cookieNameToken,
       cookieNameRefreshToken: options.cookieNameRefreshToken,
-      maxAgeRefreshToken: options.maxAgeRefreshToken,
-      sameSiteRefreshToken: options.sameSiteRefreshToken,
-      isSecureRefreshToken: options.isSecureRefreshToken
+      cookieMaxAge: options.cookieMaxAge,
+      cookieSameSite: options.cookieSameSite,
+      cookieSecure: options.cookieSecure
     })
 
     const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))

--- a/src/module.ts
+++ b/src/module.ts
@@ -65,6 +65,20 @@ export interface ModuleOptions {
    * @type string
    */
   maxAgeRefreshToken?: number;
+
+  /**
+   * The SameSite attribute for the refresh token cookie.
+   * @type string
+   * @default 'strict'
+   */
+  sameSiteRefreshToken?: 'strict' | 'lax' | 'none' | undefined;
+
+  /**
+   * The Secure attribute for the refresh token cookie.
+   * @type boolean
+   * @default true
+   */
+  isSecureRefreshToken?: boolean;
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -83,7 +97,11 @@ export default defineNuxtModule<ModuleOptions>({
     devtools: false,
     cookieNameToken: 'directus_token',
     cookieNameRefreshToken: 'directus_refresh_token',
-    maxAgeRefreshToken: 604800
+
+    // Nuxt Cookies Docs @ https://nuxt.com/docs/api/composables/use-cookie
+    maxAgeRefreshToken: 604800,
+    sameSiteRefreshToken: 'lax',
+    isSecureRefreshToken: false
   },
   setup (options, nuxt) {
     nuxt.options.runtimeConfig.public = nuxt.options.runtimeConfig.public || {}
@@ -97,7 +115,9 @@ export default defineNuxtModule<ModuleOptions>({
       devtools: options.devtools,
       cookieNameToken: options.cookieNameToken,
       cookieNameRefreshToken: options.cookieNameRefreshToken,
-      maxAgeRefreshToken: options.maxAgeRefreshToken
+      maxAgeRefreshToken: options.maxAgeRefreshToken,
+      sameSiteRefreshToken: options.sameSiteRefreshToken,
+      isSecureRefreshToken: options.isSecureRefreshToken
     })
 
     const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))

--- a/src/runtime/composables/useDirectusAuth.ts
+++ b/src/runtime/composables/useDirectusAuth.ts
@@ -185,7 +185,7 @@ export const useDirectusAuth = () => {
     createUser,
     register,
     inviteUser,
-    inviteAccept,
+    acceptInvite,
     loginWithProvider
   }
 }

--- a/src/runtime/composables/useDirectusAuth.ts
+++ b/src/runtime/composables/useDirectusAuth.ts
@@ -186,6 +186,7 @@ export const useDirectusAuth = () => {
     register,
     inviteUser,
     acceptInvite,
-    loginWithProvider
+    loginWithProvider,
+    setAuthCookies
   }
 }

--- a/src/runtime/composables/useDirectusToken.ts
+++ b/src/runtime/composables/useDirectusToken.ts
@@ -20,9 +20,9 @@ export const useDirectusToken = () => {
     }
 
     const cookie = useCookie<string | null>(name, {
-      maxAge: config.directus.maxAgeRefreshToken,
-      sameSite: config.directus.sameSiteRefreshToken,
-      secure: config.directus.isSecureRefreshToken
+      maxAge: config.directus.cookieMaxAge,
+      sameSite: config.directus.cookieSameSite,
+      secure: config.directus.cookieSecure
     })
     nuxtApp._cookies[name] = cookie
     return cookie

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -5,7 +5,7 @@ import { useDirectusUser } from './composables/useDirectusUser';
 import { useDirectusAuth } from './composables/useDirectusAuth';
 
 export default defineNuxtPlugin(async (nuxtApp) => {
-
+  
   const config = useRuntimeConfig();
   const { fetchUser } = useDirectusAuth();
   const { token, checkAutoRefresh } = useDirectusToken();
@@ -19,12 +19,10 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     }
   }
 
-  nuxtApp.hook('app:created', async () => {
-    if (process.server) {
-      await checkAutoRefresh();  
-      await checkIfUserExists();
-    }
-  })
+  // do the checks server-side, instead of using hook 'app:created', 
+  // as this hook is not called on SSR=true (static generation)
+  await checkAutoRefresh();
+  await checkIfUserExists();
 
   nuxtApp.hook('page:start', async () => {
     if (process.client) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "./playground/.nuxt/tsconfig.json"
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "module": "ESNext"
+  }
 }


### PR DESCRIPTION
I was trying to get acceptInvite, and inviteUsers functions to work, so:
1. I needed to install with `pnpm add github:Intevel/nuxt-directus`. This is when I got the error that tsconfig.json `extends` does not exist. Fixed by having the minimal required config instead. 
> File ./playground/.nuxt/tsconfig.json does not exists.
2. Fixed a typo: : inviteAccept renamed to acceptInvite.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
