### PR TITLE
docs: fix usedirectustoken

### DIFF
--- a/docs/content/2.composables/3.useDirectusToken.md
+++ b/docs/content/2.composables/3.useDirectusToken.md
@@ -2,13 +2,45 @@
 
 ---
 
-You can use this composable to get the jwt token, it is used internally to get the directus_token cookie.
+### `token`
+
+::alert{type="warning"}
+this composable will return the token currently save in your cookie, to refresh your token use [`refreshTokens`](/composables/usedirectustoken#refreshtokens)  
+::
+
+You can use this composable to get the jwt token, it is used internally to get the _directus_token_ cookie.
+
+**Return:** `string`
+
+```vue
+<script setup>
+const { token } = useDirectusToken();
+
+console.log(token.value);
+</script>
+```
+
+
+### `expires`
+
+You can use this composable to get the expire time of your token in a UNIX timestamp format. 
+
+**Return:** `number`
+
+```vue
+<script setup>
+const { expires } = useDirectusToken();
+
+console.log(expires.value);
+</script>
+```
+
+
+### `refreshTokens`
 
 ::alert{type="success"}
 Currently, we have plans to add auto refresh token as an opt-in feature, but there is no ETA. [ More info **Issue 56**](https://github.com/directus-community/nuxt-directus/issues/56)
 ::
-
-### `refreshTokens`
 
 This composable function renews the token if you have a valid refesh_token in your cookie.
 The function will save the new token in the cookie if the renewal succeeds, if you don't need to manage the new token manually you can use the simple setup.
@@ -34,51 +66,6 @@ const newToken = refreshTokens();
 ```
 
 ::
-
-### `token`
-
-You can use this composable to get the jwt token, it is used internally to get the _directus_token_ cookie.
-
-**Return:** `string`
-
-```vue
-<script setup>
-const { token } = useDirectusToken();
-
-const tokenString = token();
-</script>
-```
-
-### `refreshToken`
-
-::alert{type="warning"}
-this composable will return the token curretly save in your cookie, to refresh your token use [`refreshTokens`](/composables/usedirectustoken#refreshtokens)  
-::
-
-You can use this composable to get the jwt token, it is used internally to get the _directus_token_ cookie.
-
-**Return:** `string`
-
-```vue
-<script setup>
-const { token } = useDirectusToken();
-
-console.log(token());
-</script>
-```
-### `expires`
-
-You can use this composable to get the expire time of your token in a UNIX timestamp format. 
-
-**Return:** `number`
-
-```vue
-<script setup>
-const { expires } = useDirectusToken();
-
-console.log(expires());
-</script>
-```
 
 ::feedback-box
 ::


### PR DESCRIPTION

## Description
I found some careless mistakes in the documentation of usedirectustoken (double occurrence of 'refreshToken' as well as incorrect content of 'token') and also noticed that the calls to 'token' and 'expires' were treated as functions when they are not. Therefore, I have changed them to 'token.value' and 'expires.value'.

Additionally, I took the liberty of rearranging the sections as I found them irrelevant. 😉

closes #176 

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
