### PR TITLE
fix: wrong default cookieMaxAge

### DIFF
--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -40,9 +40,9 @@ The function that get called if the `autoRefresh` fail
 
 ## `cookieMaxAge`
 
-- Default: `604800`
+- Default: `604800000`
 
-Need to be the same as specified in your directus config; this is the max amount of milliseconds that your refresh cookie will be kept in the browser. 
+Need to be the same as specified in your directus env config ([defaults to `7d`](https://docs.directus.io/self-hosted/config-options.html#security)); this is the max amount of milliseconds that your refresh cookie will be kept in the browser. This value could be configured in a more *human readable* way as `7 * 24 * 60 * 60 * 1000`.
 
 Auto refesh tokens
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -49,7 +49,7 @@ export interface ModuleOptions {
   /**
    * Token Cookie Name
    * @type string
-   @ default 'directus_token'
+   * @ default 'directus_token'
    */
   cookieNameToken?: string;
   /**
@@ -112,8 +112,8 @@ export default defineNuxtModule<ModuleOptions>({
     cookieSameSite: 'lax',
     cookieSecure: false
   },
-  setup(options, nuxt) {
-    nuxt.options.runtimeConfig.public = nuxt.options.runtimeConfig.public || {};
+  setup (options, nuxt) {
+    nuxt.options.runtimeConfig.public = nuxt.options.runtimeConfig.public || {}
     nuxt.options.runtimeConfig.public.directus = defu(
       nuxt.options.runtimeConfig.public.directus,
       {
@@ -130,17 +130,18 @@ export default defineNuxtModule<ModuleOptions>({
         cookieSameSite: options.cookieSameSite,
         cookieSecure: options.cookieSecure
       })
-      
+
     const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))
     nuxt.options.build.transpile.push(runtimeDir)
 
     addPlugin(resolve(runtimeDir, 'plugin'))
     addImportsDir(resolve(runtimeDir, 'composables'))
     if (options.maxAgeRefreshToken) {
+      // eslint-disable-next-line no-console
       console.warn(
         'maxAgeRefreshToken is deprecated, please use cookieMaxAge instead'
-        );
-      }
+      )
+    }
 
     if (options.devtools) {
       const adminUrl = joinURL(nuxt.options.runtimeConfig.public.directus.url, '/admin/')

--- a/src/module.ts
+++ b/src/module.ts
@@ -60,18 +60,18 @@ export interface ModuleOptions {
   cookieNameRefreshToken?: string;
 
   /**
-   * The max age for auth cookies in seconds.
+   * The max age for auth cookies in milliseconds.
    * This should match your directus env key REFRESH_TOKEN_TTL
    * @type string
-   * @default 604800
+   * @default 604800000
    */
   cookieMaxAge?: number;
 
   /**
-   * The max age for auth cookies in seconds.
+   * The max age for auth cookies in milliseconds.
    * This should match your directus env key REFRESH_TOKEN_TTL
    * @type string
-   * @default 604800
+   * @default 604800000
    */
   maxAgeRefreshToken?: number;
 
@@ -108,7 +108,7 @@ export default defineNuxtModule<ModuleOptions>({
     cookieNameRefreshToken: 'directus_refresh_token',
 
     // Nuxt Cookies Docs @ https://nuxt.com/docs/api/composables/use-cookie
-    cookieMaxAge: 604800,
+    cookieMaxAge: 604800000,
     cookieSameSite: 'lax',
     cookieSecure: false
   },


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Fixes #181 
The default value for `cookieMaxAge` was in seconds instead of milliseconds as stated in the doc.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
