### PR TITLE
fix: nuxt env naming convention for directus url

### DIFF
--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -17,7 +17,7 @@ export default {
 
 - No default - **Required**
 
-The url to which requests are made to. 
+The url to which requests are made to. It is possible to set/change it at runtime via `NUXT_PUBLIC_DIRECTUS_URL` env variable.
 
 ## `autoFetch`
 

--- a/docs/content/1.getting-started/2.options.md
+++ b/docs/content/1.getting-started/2.options.md
@@ -40,9 +40,9 @@ The function that get called if the `autoRefresh` fail
 
 ## `cookieMaxAge`
 
-- Default: `604800`
+- Default: `604800000`
 
-Need to be the same as specified in your directus config; this is the max amount of milliseconds that your refresh cookie will be kept in the browser. 
+Need to be the same as specified in your directus env config ([defaults to `7d`](https://docs.directus.io/self-hosted/config-options.html#security)); this is the max amount of milliseconds that your refresh cookie will be kept in the browser. This value could be configured in a more *human readable* way as `7 * 24 * 60 * 60 * 1000`.
 
 Auto refesh tokens
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -8,7 +8,7 @@ import { DirectusQueryParams } from './runtime/types'
 export interface ModuleOptions {
   /**
    * Directus API URL
-   * @default process.env.NUXT_DIRECTUS_URL
+   * @default process.env.NUXT_PUBLIC_DIRECTUS_URL
    * @type string
    */
   url?: string;
@@ -100,7 +100,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
   },
   defaults: {
-    url: process.env.NUXT_DIRECTUS_URL,
+    url: process.env.NUXT_PUBLIC_DIRECTUS_URL,
     autoFetch: true,
     autoRefresh: false,
     devtools: false,

--- a/src/module.ts
+++ b/src/module.ts
@@ -60,18 +60,18 @@ export interface ModuleOptions {
   cookieNameRefreshToken?: string;
 
   /**
-   * The max age for auth cookies in seconds.
+   * The max age for auth cookies in milliseconds.
    * This should match your directus env key REFRESH_TOKEN_TTL
    * @type string
-   * @default 604800
+   * @default 604800000
    */
   cookieMaxAge?: number;
 
   /**
-   * The max age for auth cookies in seconds.
+   * The max age for auth cookies in milliseconds.
    * This should match your directus env key REFRESH_TOKEN_TTL
    * @type string
-   * @default 604800
+   * @default 604800000
    */
   maxAgeRefreshToken?: number;
 
@@ -108,7 +108,7 @@ export default defineNuxtModule<ModuleOptions>({
     cookieNameRefreshToken: 'directus_refresh_token',
 
     // Nuxt Cookies Docs @ https://nuxt.com/docs/api/composables/use-cookie
-    cookieMaxAge: 604800,
+    cookieMaxAge: 604800000,
     cookieSameSite: 'lax',
     cookieSecure: false
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Didn't open an Issue for this, but basically since the changes in #127 the default value for `directus.url` hasn't been updated to follow the naming convention of the [public `runtimeConfig` env variables](https://nuxt.com/docs/api/configuration/nuxt-config#runtimeconfig)

Quoting the docs:
> Anything under `public` and `app` will be exposed to the frontend as well. Values are automatically replaced by matching env variables at runtime, e.g. setting an environment variable `NUXT_API_KEY=my-api-key` `NUXT_PUBLIC_BASE_URL=/foo/` would overwrite the two values in the example below.
>Example:
>```ts
>  export default {
>    runtimeConfig: {
>      apiKey: '' // Default to an empty string, automatically set at runtime using process.env.NUXT_API_KEY
>      public: {
>        baseURL: '' // Exposed to the frontend as well.
>      }
>    }
>  }
>```

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
