### PR TITLE
Fix invalid url issue

### DIFF
--- a/src/runtime/composables/useDirectusFiles.ts
+++ b/src/runtime/composables/useDirectusFiles.ts
@@ -32,7 +32,7 @@ export const useDirectusFiles = () => {
     fileId: string,
     options?: DirectusThumbnailOptions
   ): string => {
-    const url = new URL(`${directusUrl}assets/${fileId}`)
+    const url = new URL(`${directusUrl}/assets/${fileId}`)
     if (options) {
       if (options.width) { url.searchParams.append('width', options.width.toFixed(0)) }
       if (options.height) { url.searchParams.append('height', options.height.toFixed(0)) }

--- a/src/runtime/composables/useDirectusUrl.ts
+++ b/src/runtime/composables/useDirectusUrl.ts
@@ -1,6 +1,8 @@
-import { useRuntimeConfig } from '#app'
+import { useRuntimeConfig } from "#app";
+import { withoutTrailingSlash } from "ufo";
 
 export const useDirectusUrl = (): string => {
-  const config = useRuntimeConfig()
-  return config.public.directus.url.replace(/\/$/, '')
-}
+  const config = useRuntimeConfig();
+  const url = config.public.directus.url;
+  return withoutTrailingSlash(url);
+};

--- a/src/runtime/composables/useDirectusUrl.ts
+++ b/src/runtime/composables/useDirectusUrl.ts
@@ -2,5 +2,5 @@ import { useRuntimeConfig } from '#app'
 
 export const useDirectusUrl = (): string => {
   const config = useRuntimeConfig()
-  return config.public.directus.url
+  return config.public.directus.url.replace(/\/$/, '')
 }


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
In the original code, concatenating directusUrl with the path to the asset using the ${directusUrl}assets/${fileId}. In the updated code, format the URL by using ${directusUrl}/assets/${fileId}, ensuring that there is a forward slash (/) between directusUrl and assets, which will fix the invalid URL issue.

The original code simply returned the directus.url from the config.public object. I am applying a regular expression to remove a trailing slash (/) from the URL. This change ensures that the URL does not end with a slash, which can help prevent issues related to URL formatting and consistency.

The problem these changes solve is an "invalid URL issue on files." By making these adjustments, ensuring that the URLs used for assets are correctly formatted, can prevent errors or unexpected behavior when working with these URLs.

Please make any other changes needed regarding this issue.
