### PR TITLE
feat: auth and user state refresh during server to client connection

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -8,12 +8,13 @@ export default defineNuxtConfig({
   directus: {
     url: 'http://localhost:8055/',
     authConfig: {
+      useNuxtCookies: true,
       refreshTokenCookieName: 'nuxt-directus_refresh_token'
     },
     moduleConfig: {
       devtools: true,
       autoRefresh: {
-        enableMiddleware: true,
+        enableMiddleware: false,
         redirectTo: '/login',
         to: ['/restricted']
       }

--- a/src/runtime/composables/use-directus-auth.ts
+++ b/src/runtime/composables/use-directus-auth.ts
@@ -127,20 +127,16 @@ export function useDirectusAuth<TSchema extends Object> (config?: Partial<Direct
 
     const authResponse = await client.request(sdkRefresh(mode ?? defaultMode, token ?? undefined))
 
-    if (authResponse) {
-      if (updateStates !== false) {
-        if (updateTokens !== false) {
-          await setTokens(authResponse)
-        }
-        if (readMe !== false) {
-          await readMyself(readMe)
-        }
+    if (updateStates !== false) {
+      if (updateTokens !== false) {
+        await setTokens(authResponse ?? null)
       }
-
-      return authResponse
-    } else {
-      return null
+      if (readMe !== false) {
+        await readMyself(readMe)
+      }
     }
+
+    return authResponse
   }
 
   /**

--- a/src/runtime/composables/use-directus-tokens.ts
+++ b/src/runtime/composables/use-directus-tokens.ts
@@ -5,7 +5,6 @@ import type {
   ModuleOptions
 } from '../types'
 import {
-  type Ref,
   useCookie,
   useState,
   useRuntimeConfig
@@ -29,7 +28,7 @@ export const useDirectusTokens = (useStaticToken?: boolean | string):DirectusTok
     cookieSecure: secure
   } = directusConfig.authConfig as ModuleOptions['authConfig']
 
-  const tokens: Ref<AuthenticationData | null> = useState(authStateName)
+  const tokens = useState<AuthenticationData | null>(authStateName, () => null)
 
   function refreshToken (maxAge?: number | undefined): CookieRef<string | null | undefined> {
     const cookie = useCookie<string | null>(refreshTokenCookieName!, { maxAge, httpOnly, sameSite, secure })
@@ -37,6 +36,7 @@ export const useDirectusTokens = (useStaticToken?: boolean | string):DirectusTok
   }
 
   const refreshTokenCookie = refreshToken().value
+
   return {
     get: () => {
       if ((useStaticToken === true || typeof useStaticToken === 'string') || (!tokens.value?.access_token && useStaticToken !== false)) {

--- a/src/runtime/plugins/auto-refresh.ts
+++ b/src/runtime/plugins/auto-refresh.ts
@@ -4,13 +4,24 @@ import {
   addRouteMiddleware,
   defineNuxtPlugin,
   navigateTo,
+  useRequestHeaders,
   useRuntimeConfig
 } from '#imports'
 
-export default defineNuxtPlugin((nuxtApp) => {
+function cookieParser (cookie: string): Record<string, string> {
+  return cookie.split(';').reduce((acc: Record<string, string>, cookie) => {
+    const [key, value] = cookie.split('=')
+    acc[key.trim()] = value
+    return acc
+  }, {})
+}
+
+export default defineNuxtPlugin(async (nuxtApp) => {
   const {
+    url,
     authConfig: {
-      useNuxtCookies
+      useNuxtCookies,
+      refreshTokenCookieName
     },
     moduleConfig: {
       autoRefresh: {
@@ -30,10 +41,56 @@ export default defineNuxtPlugin((nuxtApp) => {
     user
   } = useDirectusAuth({ useStaticToken: false })
 
-  if (!tokens.value?.access_token && (!!refreshTokenCookie().value || !useNuxtCookies)) {
-    nuxtApp.hook('app:mounted', async () => {
-      await refreshTokens()
-    })
+  const headers = useRequestHeaders(['cookie'])
+
+  if (process.server && headers.cookie) {
+    if (useNuxtCookies) {
+      const cookies = cookieParser(headers.cookie)
+
+      if (cookies[refreshTokenCookieName]) {
+        tokens.value = await refreshTokens({
+          refreshToken: cookies[refreshTokenCookieName],
+          updateStates: false
+        }).catch(e => console.error(e))
+
+        refreshTokenCookie().value = tokens.value?.refresh_token
+      }
+    } // else {
+    //   console.log('headers.cookie', headers.cookie)
+    //   const resp = await $fetch.raw('auth/refresh', {
+    //     baseURL: url,
+    //     method: 'POST',
+    //     headers,
+    //     body: {
+    //       mode: 'cookie'
+    //     }
+    //   }).catch(e => console.error(e))
+    //   tokens.value = resp?._data
+    //   const resHeaders = resp?.headers
+    //   console.log('tokens.value', resp?.headers)
+    // }
+
+    if (tokens.value && tokens.value.access_token) {
+      user.value = await $fetch('users/me', {
+        baseURL: url,
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${tokens.value.access_token}`
+        }
+      })
+    }
+  }
+
+  if (process.client && !tokens.value?.access_token && (!!refreshTokenCookie().value || !useNuxtCookies)) {
+    if (useNuxtCookies) {
+      nuxtApp.hook('app:beforeMount', async () => {
+        await refreshTokens()
+      })
+    } else {
+      nuxtApp.hook('app:mounted', async () => {
+        await refreshTokens()
+      })
+    }
   }
 
   if (enableMiddleware) {


### PR DESCRIPTION
This changes affects:
- `auto-refresh` implementation
- fixes to `useDirectusAuth` and `useDirectusTokens`

## What is this?

Since I managed to fix all issues (known to me) in regard `login` and `refreshTokens` functions (making sure no information were leaked and promises were respected) I wanted to fix the page _flash_ that happens when the DOM should be updated by the currently authenticated user's information.

> [!NOTE]
> To my knowledge the page _flash_ happens because the browser is able to render the DOM before fully mounting vue's logic.

## Sequence of operations

The following is the sequence of operations while using the default module's options in the event of a user was authenticated in a prior session and still has a valid `refresh_token` in their cookies:

### `ssr: true` and `useNuxtCookies: false`
```mermaid
sequenceDiagram
    participant Client
    participant Server
    participant Directus
    Client->>Server: first page request + cookies
    activate Server
    Server->>Server: auth+user states check
    Server->>Directus: cookie found, no states, refresh all
    activate Directus
    Directus-->>Server: new tokens + user's data
    deactivate Directus
    Server-->>Client: page with auth+user states.
    activate Client
    deactivate Server
    Client-->>Client: access_token expire check
    Client->>Directus: access_token expired
    activate Directus
    Directus-->Client: new access_token
    deactivate Directus
    deactivate Client
```

---

#### `ssr: false` or `useNuxtCookies: false`
```mermaid
sequenceDiagram
    participant Client
    participant Server
    participant Directus
    Client->>Server: first page request
    activate Server
    activate Client
    Server-->>Client: page response
    deactivate Server
    Client->>Client: auth+user states check
    Client->>Directus: cookie found, no states, refresh all
    activate Directus
    Directus-->>Client: new tokens + user's data
    deactivate Directus
    Client-->>Client: access_token expire check
    Client->>Directus: access_token expired
    activate Directus
    Directus-->Client: new access_token
    deactivate Directus    
    deactivate Client
```