### PR TITLE
Add params in useDirectusItems.ts (updateItem&createItems)

### DIFF
--- a/src/runtime/composables/useDirectusItems.ts
+++ b/src/runtime/composables/useDirectusItems.ts
@@ -67,7 +67,8 @@ export const useDirectusItems = () => {
   const createItems = async <T>(data: DirectusItemCreation): Promise<T[]> => {
     const items = await directus<{ data: T[] }>(`/items/${data.collection}`, {
       method: 'POST',
-      body: data.items
+      body: data.items,
+      params: data.params
     })
     return items.data
   }
@@ -84,7 +85,8 @@ export const useDirectusItems = () => {
       `/items/${data.collection}/${data.id}`,
       {
         method: 'PATCH',
-        body: data.item
+        body: data.item,
+        params: data.params
       }
     )
     return item?.data

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -74,12 +74,14 @@ export interface DirectusItemMetaRequest extends DirectusItemRequest {
 export interface DirectusItemCreation {
   collection: string;
   items: Array<Object> | Object;
+  params?: DirectusQueryParams;
 }
 
 export interface DirectusItemUpdate {
   collection: string;
   id: string;
   item: Object;
+  params?: DirectusQueryParams;
 }
 export interface DirectusItemDeletion {
   collection: string;


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

This pull request introduces a minor but significant change to the `createItems` and `updateItems` functions. 

Previously, these functions did not include the `params: data.params` line, which could potentially limit their functionality and flexibility. By including this line, we allow for additional parameters to be passed into these functions, enhancing their versatility and adaptability to various use cases.

Here are the changes made:


```typescript
// In createItems function
createItems(data) {
  // ...existing code...
  params: data.params
  // ...existing code...
}

// In updateItems function
updateItems(data) {
  // ...existing code...
  params: data.params
  // ...existing code...
}
```
#257 

## Checklist:
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)




