### PR TITLE
fix: update package exports types

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -5,6 +5,8 @@ import { defineNuxtModule, addPlugin, addImportsDir } from '@nuxt/kit'
 import { joinURL } from 'ufo'
 import { DirectusQueryParams } from './runtime/types'
 
+export type * from './runtime/types'
+
 export interface ModuleOptions {
   /**
    * Directus API URL


### PR DESCRIPTION
Export the package's runtime types instead of only the module's configuration types in the package's `exports` field.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
With this I want to get back to https://github.com/Intevel/nuxt-directus/issues/244, which isn't quite fixed yet. Currently the package only exports the `ModuleOptions` types. Hence with moduleResolution type `bundler` (introduced with the latest [Nuxt versions](https://nuxt.com/docs/guide/going-further/features#typescriptbundlerresolution)), it is not possible to e.g. `import type { DirectusFile } from 'nuxt-directus'` without type errors. This change ensures to export the runtime types instead of only the module's configuration types.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] <s>My change requires a change to the documentation.</s>
- [ ] <s>I have updated the documentation accordingly.</s>
- [ ] <s>I have added tests to cover my changes (if not applicable, please state why)</s>

Tested on a local Nuxt v3.12.2 with `typescriptBundlerResolution: true`.