### PR TITLE
docs: clarify the use of useDirectusAuth().createUser() and a static …

### DIFF
--- a/docs/content/2.composables/1.useDirectusAuth.md
+++ b/docs/content/2.composables/1.useDirectusAuth.md
@@ -43,6 +43,8 @@ const onSubmit = async () => {
 
 Create a new Directus user, can also be used as `register()`. **Email and password are required**, partial user object is given.
 
+May requires the module's option [`token`](/getting-started/options#token) to be set if you need to create a user sign in form for example.
+
 - **Arguments:**
   - data: [`DirectusUserCreation`](https://github.com/Intevel/nuxt-directus/blob/main/src/runtime/types/index.d.ts#L95)
 - **Returns:** [`Promise<DirectusUser>`](https://docs.directus.io/reference/system/users/#the-user-object)


### PR DESCRIPTION
Documents the `useStaticToken` that was previously missing in the documentation for `useDirectusAuth().createUser()`.

## Types of changes

Enhance documentation.


## Description

Creating a user while using a static token is handy for those wishing to create a sign in form. This commit simply state it in the documentation.

## Checklist:

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
