### PR TITLE
Add useDirectusFields() composable

### DIFF
--- a/docs/content/2.composables/9.useDirectusFields.md
+++ b/docs/content/2.composables/9.useDirectusFields.md
@@ -1,0 +1,173 @@
+# `useDirectusFields`
+
+---
+
+> Check out the Directus [Fields](https://docs.directus.io/reference/system/fields.html) documentation.
+
+### `getFields`
+
+Get all fields in a specific collection
+
+- **Arguments:**
+
+  - data: [`DirectusFieldsRequest`](https://github.com/Intevel/nuxt-directus/blob/main/src/runtime/types/index.d.ts)
+    - collection?: `string`
+
+- **Returns:** `Promise<DirectusField[]>`
+
+```vue [pages/example.vue]
+<script setup lang="ts">
+const { getFields } = useDirectusFields();
+
+const fetchFields = async () => {
+  try {
+    const fields = await getFields({
+      collection: "articles"
+    });
+    // fields will contain an array of DirectusField objects
+  } catch (e) {
+    // Handle error
+  }
+};
+</script>
+```
+
+### `getField`
+
+Get a specific field in a collection
+
+- **Arguments:**
+
+  - data: [`DirectusFieldRequest`](https://github.com/Intevel/nuxt-directus/blob/main/src/runtime/types/index.d.ts)
+    - collection: `string`
+    - field?: `string`
+
+- **Returns:** `Promise<DirectusField>`
+
+```vue [pages/example.vue]
+<script setup lang="ts">
+const { getField } = useDirectusFields();
+
+const fetchField = async () => {
+  try {
+    const field = await getField({
+      collection: "articles",
+      field: "title"
+    });
+    // field will contain a DirectusField object
+  } catch (e) {
+    // Handle error
+  }
+};
+</script>
+```
+
+### `createField`
+
+Create a new field in a collection
+
+- **Arguments:**
+
+  - data: [`DirectusFieldCreation`](https://github.com/Intevel/nuxt-directus/blob/main/src/runtime/types/index.d.ts)
+    - collection: `string`
+    - field: `string`
+    - type: `string`
+    - meta?: `Record<string, any>`
+    - schema?: `Record<string, any>`
+
+- **Returns:** `Promise<DirectusField>`
+
+```vue [pages/example.vue]
+<script setup lang="ts">
+const { createField } = useDirectusFields();
+
+const createNewField = async () => {
+  try {
+    const field = await createField({
+      collection: "articles",
+      field: "subtitle",
+      type: "string",
+      meta: {
+        interface: "input",
+        special: null,
+        required: false
+      },
+      schema: {
+        is_nullable: true,
+        default_value: null
+      }
+    });
+    // field will contain the newly created DirectusField
+  } catch (e) {
+    // Handle error
+  }
+};
+</script>
+```
+
+### `updateField`
+
+Update an existing field in a collection
+
+- **Arguments:**
+
+  - data: [`DirectusFieldUpdate`](https://github.com/Intevel/nuxt-directus/blob/main/src/runtime/types/index.d.ts)
+    - collection: `string`
+    - field: `string`
+    - meta?: `Record<string, any>`
+    - schema?: `Record<string, any>`
+
+- **Returns:** `Promise<DirectusField>`
+
+```vue [pages/example.vue]
+<script setup lang="ts">
+const { updateField } = useDirectusFields();
+
+const updateExistingField = async () => {
+  try {
+    const field = await updateField({
+      collection: "articles",
+      field: "subtitle",
+      meta: {
+        required: true
+      },
+      schema: {
+        is_nullable: false
+      }
+    });
+    // field will contain the updated DirectusField
+  } catch (e) {
+    // Handle error
+  }
+};
+</script>
+```
+
+### `deleteField`
+
+Delete a field from a collection
+
+- **Arguments:**
+
+  - data: [`DirectusFieldRequest`](https://github.com/Intevel/nuxt-directus/blob/main/src/runtime/types/index.d.ts)
+    - collection: `string`
+    - field: `string`
+
+- **Returns:** `Promise<void>`
+
+```vue [pages/example.vue]
+<script setup lang="ts">
+const { deleteField } = useDirectusFields();
+
+const removeField = async () => {
+  try {
+    await deleteField({
+      collection: "articles",
+      field: "subtitle"
+    });
+    // Field has been deleted
+  } catch (e) {
+    // Handle error
+  }
+};
+</script>

--- a/docs/content/2.composables/9.useDirectusFields.md
+++ b/docs/content/2.composables/9.useDirectusFields.md
@@ -17,18 +17,26 @@ Get all fields in a specific collection
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-const { getFields } = useDirectusFields();
+  const { getFields } = useDirectusFields();
 
-const fetchFields = async () => {
-  try {
-    const fields = await getFields({
-      collection: "articles"
-    });
-    // fields will contain an array of DirectusField objects
-  } catch (e) {
-    // Handle error
+  interface Field {
+    collection: string;
+    field: string;
+    type: string;
+    schema: Object;
+    meta: Object;
   }
-};
+
+  const fetchFields = async () => {
+    try {
+      const fields = await getFields<Field>({
+        collection: "articles"
+      });
+      // fields will contain an array of Field objects
+    } catch (e) {
+      // Handle error
+    }
+  };
 </script>
 ```
 

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -25,6 +25,9 @@
     <button style="margin-top: 25px" @click="fetchCollections">
       Fetch Collections
     </button>
+    <button style="margin-top: 25px" @click="fetchFields">
+      Fetch Fields
+    </button>
     <button style="margin-top: 25px" @click="logUser">
       Log User
     </button>
@@ -57,6 +60,7 @@ const { login, loginWithProvider, logout } = useDirectusAuth()
 const user = useDirectusUser()
 const { getItems, getItemById, createItems, deleteItems } = useDirectusItems()
 const { getCollections } = useDirectusCollections()
+const { getFields } = useDirectusFields()
 const router = useRouter()
 const { token } = useDirectusToken()
 
@@ -73,6 +77,14 @@ interface Article {
   title: string;
   content: string;
   status: string;
+}
+
+interface Field {
+  collection: string;
+  field: string;
+  type: string;
+  schema: Object;
+  meta: Object;
 }
 
 let articleIds: (string | number | undefined)[] = []
@@ -147,6 +159,17 @@ const fetchCollections = async () => {
   try {
     const collections = await getCollections()
     console.log(collections)
+
+    router.push('/d')
+  } catch (e) {}
+}
+
+const fetchFields = async () => {
+  try {
+    const fields = await getFields<Field>({
+      collection: 'Articles'
+    });
+    console.log(fields)
 
     router.push('/d')
   } catch (e) {}

--- a/src/runtime/composables/useDirectusFields.ts
+++ b/src/runtime/composables/useDirectusFields.ts
@@ -1,0 +1,84 @@
+import {
+  DirectusFieldRequest,
+  DirectusFieldCreation,
+  DirectusFieldUpdate,
+  DirectusFieldsRequest
+} from '../types'
+import { useDirectus } from './useDirectus'
+
+export const useDirectusFields = () => {
+  const directus = useDirectus()
+
+  const getFields = async <T>(
+    data: DirectusFieldsRequest
+  ): Promise<T> => {
+    const fields = await directus<{ data: T }>(
+      `/fields/${data.collection}`,
+      {
+        method: 'GET'
+      }
+    )
+    return fields.data
+  }
+
+  const getField = async <T>(data: DirectusFieldRequest): Promise<T> => {
+    if (!data.field) {
+      throw new Error('Field name is required')
+    }
+    const field = await directus<{ data: T }>(
+      `/fields/${data.collection}/${data.field}`,
+      {
+        method: 'GET'
+      }
+    )
+    return field.data
+  }
+
+  const createField = async <T>(data: DirectusFieldCreation): Promise<T> => {
+    const field = await directus<{ data: T }>(`/fields/${data.collection}`, {
+      method: 'POST',
+      body: {
+        field: data.field,
+        type: data.type,
+        meta: data.meta,
+        schema: data.schema
+      }
+    })
+    return field.data
+  }
+
+  const updateField = async <T>(data: DirectusFieldUpdate): Promise<T> => {
+    const field = await directus<{ data: T }>(
+      `/fields/${data.collection}/${data.field}`,
+      {
+        method: 'PATCH',
+        body: {
+          meta: data.meta,
+          schema: data.schema
+        }
+      }
+    )
+    return field.data
+  }
+
+  const deleteField = async <T>(data: DirectusFieldRequest): Promise<T> => {
+    if (!data.field) {
+      throw new Error('Field name is required')
+    }
+    const field = await directus<{ data: T }>(
+      `/fields/${data.collection}/${data.field}`,
+      {
+        method: 'DELETE'
+      }
+    )
+    return field.data
+  }
+
+  return {
+    getFields,
+    getField,
+    createField,
+    updateField,
+    deleteField
+  }
+}

--- a/src/runtime/composables/useDirectusFields.ts
+++ b/src/runtime/composables/useDirectusFields.ts
@@ -2,17 +2,18 @@ import {
   DirectusFieldRequest,
   DirectusFieldCreation,
   DirectusFieldUpdate,
-  DirectusFieldsRequest
+  DirectusFieldsRequest,
+  DirectusField
 } from '../types'
 import { useDirectus } from './useDirectus'
 
 export const useDirectusFields = () => {
   const directus = useDirectus()
 
-  const getFields = async <T>(
+  const getFields = async (
     data: DirectusFieldsRequest
-  ): Promise<T> => {
-    const fields = await directus<{ data: T }>(
+  ): Promise<DirectusField[]> => {
+    const fields = await directus<{ data: DirectusField[] }>(
       `/fields/${data.collection}`,
       {
         method: 'GET'
@@ -21,11 +22,11 @@ export const useDirectusFields = () => {
     return fields.data
   }
 
-  const getField = async <T>(data: DirectusFieldRequest): Promise<T> => {
+  const getField = async (data: DirectusFieldRequest): Promise<DirectusField> => {
     if (!data.field) {
       throw new Error('Field name is required')
     }
-    const field = await directus<{ data: T }>(
+    const field = await directus<{ data: DirectusField }>(
       `/fields/${data.collection}/${data.field}`,
       {
         method: 'GET'
@@ -34,8 +35,8 @@ export const useDirectusFields = () => {
     return field.data
   }
 
-  const createField = async <T>(data: DirectusFieldCreation): Promise<T> => {
-    const field = await directus<{ data: T }>(`/fields/${data.collection}`, {
+  const createField = async (data: DirectusFieldCreation): Promise<DirectusField> => {
+    const field = await directus<{ data: DirectusField }>(`/fields/${data.collection}`, {
       method: 'POST',
       body: {
         field: data.field,
@@ -47,8 +48,8 @@ export const useDirectusFields = () => {
     return field.data
   }
 
-  const updateField = async <T>(data: DirectusFieldUpdate): Promise<T> => {
-    const field = await directus<{ data: T }>(
+  const updateField = async (data: DirectusFieldUpdate): Promise<DirectusField> => {
+    const field = await directus<{ data: DirectusField }>(
       `/fields/${data.collection}/${data.field}`,
       {
         method: 'PATCH',
@@ -61,17 +62,16 @@ export const useDirectusFields = () => {
     return field.data
   }
 
-  const deleteField = async <T>(data: DirectusFieldRequest): Promise<T> => {
+  const deleteField = async (data: DirectusFieldRequest): Promise<void> => {
     if (!data.field) {
       throw new Error('Field name is required')
     }
-    const field = await directus<{ data: T }>(
+    await directus(
       `/fields/${data.collection}/${data.field}`,
       {
         method: 'DELETE'
       }
     )
-    return field.data
   }
 
   return {

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -168,6 +168,30 @@ export interface DirectusFileRequest {
   params?: DirectusQueryParams;
 }
 
+export interface DirectusFieldsRequest {
+  collection?: string;
+}
+
+export interface DirectusFieldRequest {
+  collection: string
+  field?: string
+}
+
+export interface DirectusFieldCreation {
+  collection: string
+  field: string
+  type: string
+  meta?: Record<string, any>
+  schema?: Record<string, any>
+}
+
+export interface DirectusFieldUpdate {
+  collection: string
+  field: string
+  meta?: Record<string, any>
+  schema?: Record<string, any>
+}
+
 export interface DirectusNotificationObject {
   id?: number;
   timestamp?: string;
@@ -179,6 +203,7 @@ export interface DirectusNotificationObject {
   collection?: string;
   item?: string;
 }
+
 
 export interface DirectusCollectionRequest {
   collection?: string;

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -168,6 +168,14 @@ export interface DirectusFileRequest {
   params?: DirectusQueryParams;
 }
 
+export interface DirectusField {
+  collection: string;
+  field: string;
+  type: string;
+  meta: Record<string, any>;
+  schema: Record<string, any>;
+}
+
 export interface DirectusFieldsRequest {
   collection?: string;
 }
@@ -259,7 +267,7 @@ export interface DirectusRevision {
 export interface DirectusItemMetadata {
   total_count?: number;
   filter_count?: number;
-};
+}
 
 export interface DirectusItems<T> {
   data: NonNullable<T[]>;


### PR DESCRIPTION
This pull request introduces a new composable `useDirectusFields`, including a playground button and relevant documentation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

`useDirectusFields` exposes an important part of directus: collection fields.

* [`src/runtime/composables/useDirectusFields.ts`](diffhunk://#diff-8e965db9e5fb1fa68a95448ed45dde3fbbca9b982ee3186990644fec538f646fR1-R84): Added the `useDirectusFields` composable with methods `getFields`, `getField`, `createField`, `updateField`, and `deleteField`.

Documentation updates:

* [`docs/content/2.composables/9.useDirectusFields.md`](diffhunk://#diff-c2f5fb23a7c5ea997679e8950c0d1637f18a48259cc1a815cc0c8f74b1b6b1f5R1-R173): Added documentation for the `useDirectusFields` composable, including usage examples for each method.

Playground application updates:

* [`playground/app.vue`](diffhunk://#diff-4e70dbb4315c851802969484f0b6cf566eda24aeb43dc8b6c413e575488713d0R28-R30): Added a new button to fetch fields and integrated the `getFields` method from `useDirectusFields`. [[1]](diffhunk://#diff-4e70dbb4315c851802969484f0b6cf566eda24aeb43dc8b6c413e575488713d0R28-R30) [[2]](diffhunk://#diff-4e70dbb4315c851802969484f0b6cf566eda24aeb43dc8b6c413e575488713d0R63) [[3]](diffhunk://#diff-4e70dbb4315c851802969484f0b6cf566eda24aeb43dc8b6c413e575488713d0R82-R89) [[4]](diffhunk://#diff-4e70dbb4315c851802969484f0b6cf566eda24aeb43dc8b6c413e575488713d0R167-R177)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why) - not applicable because there are no existing tests. I'm happy to add some, but a separate MR should introduce a test framework.

